### PR TITLE
SCMOD-7158: Use thread id instead of name

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ This project configures Logback to meet the CAF Logging Standard.
     - Missing or inapplicable header fields are replaced with a dash.
 
 #### Pattern:
-    [(Time) #(Thread Id) (Log Level) (Tenant Id) (Correlation Id)] (Logger) (Log Message)  
+    [(Time) #(Process Id).(Thread Id) (Log Level) (Tenant Id) (Correlation Id)] (Logger) (Log Message)  
 
 #### Example:
-    [10:50:25.465 #009 DEBUG acme-corp    -   ] com.github.example.Logger Example Log Message
+    [10:50:25.465 #bff.009 DEBUG acme-corp    -   ] com.github.example.Logger Example Log Message
 
 To log the tenant and correlation ids the service using this configuration must use SLF4J's [MDC](https://www.slf4j.org/manual.html#mdc).  
 Example commands:

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ This project configures Logback to meet the CAF Logging Standard.
     - Missing or inapplicable header fields are replaced with a dash.
 
 #### Pattern:
-    [(Time) (Thread Name) (Log Level) (Tenant Id) (Correlation Id)] (Logger) (Log Message)  
+    [(Time) #(Thread Id) (Log Level) (Tenant Id) (Correlation Id)] (Logger) (Log Message)  
 
 #### Example:
-    [10:50:25.465 http-nio-8080-exec-9 DEBUG acme-corp                      -       ] com.github.example.Logger Example Log Message
+    [10:50:25.465 #009 DEBUG acme-corp                      -       ] com.github.example.Logger Example Log Message
 
 To log the tenant and correlation ids the service using this configuration must use SLF4J's [MDC](https://www.slf4j.org/manual.html#mdc).  
 Example commands:

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,11 @@
             <artifactId>logback-core</artifactId>
             <version>${logbackVersion}</version>
         </dependency>
+        <dependency>
+            <groupId>com.github.cafapi.util</groupId>
+            <artifactId>util-process-identifier</artifactId>
+            <version>1.16.0-118</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -66,14 +66,19 @@
         <copyrightYear>2019</copyrightYear>
         <copyrightNotice>Copyright ${copyrightYear} Micro Focus or one of its affiliates.</copyrightNotice>
         <enforceCorrectDependencies>true</enforceCorrectDependencies>
+        <logbackVersion>1.2.3</logbackVersion>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.3</version>
-            <scope>runtime</scope>
+            <version>${logbackVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <version>${logbackVersion}</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/github/cafapi/logging/CAFConsoleAppender.java
+++ b/src/main/java/com/github/cafapi/logging/CAFConsoleAppender.java
@@ -37,6 +37,6 @@ public final class CAFConsoleAppender extends ConsoleAppender<LoggingEvent>
     private static String getThreadName()
     {
         final long threadId = Thread.currentThread().getId();
-        return String.format("#%03d", threadId);
+        return String.format(Locale.ENGLISH, "#%03d", threadId);
     }
 }

--- a/src/main/java/com/github/cafapi/logging/CAFConsoleAppender.java
+++ b/src/main/java/com/github/cafapi/logging/CAFConsoleAppender.java
@@ -17,10 +17,17 @@ package com.github.cafapi.logging;
 
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.ConsoleAppender;
+import com.hpe.caf.util.processidentifier.ProcessIdentifier;
+import java.util.Locale;
 
 public final class CAFConsoleAppender extends ConsoleAppender<LoggingEvent>
 {
+    private static final String PROCESS_ID;
     private final ThreadLocal<String> threadIds;
+
+    static {
+        PROCESS_ID = ProcessIdentifier.getProcessId().toString().substring(0, 3);
+    }
 
     public CAFConsoleAppender()
     {
@@ -37,6 +44,6 @@ public final class CAFConsoleAppender extends ConsoleAppender<LoggingEvent>
     private static String getThreadName()
     {
         final long threadId = Thread.currentThread().getId();
-        return String.format(Locale.ENGLISH, "#%03d", threadId);
+        return String.format(Locale.ENGLISH, "#%s.%03d", PROCESS_ID, threadId);
     }
 }

--- a/src/main/java/com/github/cafapi/logging/CAFConsoleAppender.java
+++ b/src/main/java/com/github/cafapi/logging/CAFConsoleAppender.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Micro Focus or one of its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cafapi.logging;
+
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.ConsoleAppender;
+
+public final class CAFConsoleAppender extends ConsoleAppender<LoggingEvent>
+{
+    private final ThreadLocal<String> threadIds;
+
+    public CAFConsoleAppender()
+    {
+        this.threadIds = ThreadLocal.withInitial(CAFConsoleAppender::getThreadName);
+    }
+
+    @Override
+    protected void subAppend(final LoggingEvent event)
+    {
+        event.setThreadName(threadIds.get());
+        super.subAppend(event);
+    }
+
+    private static String getThreadName()
+    {
+        final long threadId = Thread.currentThread().getId();
+        return String.format("#%03d", threadId);
+    }
+}

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -16,7 +16,7 @@
 
 -->
 <configuration>
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <appender name="STDOUT" class="com.github.cafapi.logging.CAFConsoleAppender">
         <encoder> 
             <pattern>
                 [%.-12d{HH:mm:ss.SSS} %thread %-5level %-30.30mdc{tenantId:--} %-8.8mdc{correlationId:--}] %logger{36} %msg%n


### PR DESCRIPTION
https://portal.digitalsafe.net/browse/SCMOD-7158

Added some code so that we log the thread id instead of the name.