### PR TITLE
Changed the Process and Thread Id converter key

### DIFF
--- a/caf-logging-log4j2/src/main/java/com/github/cafapi/logging/log4j2/ProcessAndThreadIdConverter.java
+++ b/caf-logging-log4j2/src/main/java/com/github/cafapi/logging/log4j2/ProcessAndThreadIdConverter.java
@@ -22,18 +22,18 @@ import org.apache.logging.log4j.core.pattern.ConverterKeys;
 import org.apache.logging.log4j.core.pattern.LogEventPatternConverter;
 import org.apache.logging.log4j.core.pattern.PatternConverter;
 
-@Plugin(name = "ProcessAndThreadIdPatternConverter", category = PatternConverter.CATEGORY)
-@ConverterKeys({"aProcessId"})
-public final class ProcessAndThreadIdPatternConverter extends LogEventPatternConverter
+@Plugin(name = "ProcessAndThreadIdConverter", category = PatternConverter.CATEGORY)
+@ConverterKeys({"pidtid"})
+public final class ProcessAndThreadIdConverter extends LogEventPatternConverter
 {
-    private ProcessAndThreadIdPatternConverter()
+    private ProcessAndThreadIdConverter()
     {
-        super("ProcessAndThreadIdPatternConverter", "aProcessId");
+        super("ProcessAndThreadIdConverter", "pidtid");
     }
 
-    public static ProcessAndThreadIdPatternConverter newInstance(final String[] options)
+    public static ProcessAndThreadIdConverter newInstance(final String[] options)
     {
-        return new ProcessAndThreadIdPatternConverter();
+        return new ProcessAndThreadIdConverter();
     }
 
     @Override

--- a/caf-logging-log4j2/src/main/resources/log4j2.xml
+++ b/caf-logging-log4j2/src/main/resources/log4j2.xml
@@ -21,7 +21,7 @@
     <Appenders>
         <Console name="STDOUT" target="SYSTEM_OUT">
             <PatternLayout
-                pattern="[%d{HH:mm:ss.SSS}{UTC}Z %aProcessId %-5level ${%-12.-12sanitize{ %X{tenantId} }:\-} ${%-4.-4sanitize{ %X{correlationId} }:\-}] %sanitize{ %logger{30} }: %maybeJsonMsgAndEx%n" 
+                pattern="[%d{HH:mm:ss.SSS}{UTC}Z %pidtid %-5level ${%-12.-12sanitize{ %X{tenantId} }:\-} ${%-4.-4sanitize{ %X{correlationId} }:\-}] %sanitize{ %logger{30} }: %maybeJsonMsgAndEx%n" 
                 charset="UTF-8" />
         </Console>
     </Appenders>

--- a/caf-logging-logback-access-converters/src/main/java/com/github/cafapi/logging/logback/access/converters/ProcessAndThreadIdConverter.java
+++ b/caf-logging-logback-access-converters/src/main/java/com/github/cafapi/logging/logback/access/converters/ProcessAndThreadIdConverter.java
@@ -13,15 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.github.cafapi.logging.logback.converters;
+package com.github.cafapi.logging.logback.access.converters;
 
-import ch.qos.logback.core.pattern.DynamicConverter;
+import ch.qos.logback.access.pattern.AccessConverter;
+import ch.qos.logback.access.spi.IAccessEvent;
 import com.github.cafapi.logging.common.ProcessAndThreadIdProvider;
 
-public final class ProcessAndThreadIdPatternConverter<E> extends DynamicConverter<E>
+public final class ProcessAndThreadIdConverter extends AccessConverter
 {
     @Override
-    public String convert(final E event)
+    public String convert(final IAccessEvent event)
     {
         return ProcessAndThreadIdProvider.getId();
     }

--- a/caf-logging-logback-converters/src/main/java/com/github/cafapi/logging/logback/converters/ProcessAndThreadIdConverter.java
+++ b/caf-logging-logback-converters/src/main/java/com/github/cafapi/logging/logback/converters/ProcessAndThreadIdConverter.java
@@ -13,16 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.github.cafapi.logging.logback.access.converters;
+package com.github.cafapi.logging.logback.converters;
 
-import ch.qos.logback.access.pattern.AccessConverter;
-import ch.qos.logback.access.spi.IAccessEvent;
+import ch.qos.logback.core.pattern.DynamicConverter;
 import com.github.cafapi.logging.common.ProcessAndThreadIdProvider;
 
-public final class ProcessAndThreadIdPatternConverter extends AccessConverter
+public final class ProcessAndThreadIdConverter<E> extends DynamicConverter<E>
 {
     @Override
-    public String convert(final IAccessEvent event)
+    public String convert(final E event)
     {
         return ProcessAndThreadIdProvider.getId();
     }

--- a/caf-logging-logback/src/main/resources/logback.xml
+++ b/caf-logging-logback/src/main/resources/logback.xml
@@ -16,8 +16,8 @@
 
 -->
 <configuration>
-    <conversionRule conversionWord="aProcessId"
-                    converterClass="com.github.cafapi.logging.logback.converters.ProcessAndThreadIdPatternConverter" />
+    <conversionRule conversionWord="pidtid"
+                    converterClass="com.github.cafapi.logging.logback.converters.ProcessAndThreadIdConverter" />
     <conversionRule conversionWord="sanitize"
                     converterClass="com.github.cafapi.logging.logback.converters.SanitizeConverter" />
     <conversionRule conversionWord="maybeJsonMsgAndEx"
@@ -28,7 +28,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder> 
             <pattern>
-                [%date{HH:mm:ss.SSS,UTC}Z %aProcessId %-5level %-12.-12sanitize(%mdc{tenantId:--}) %-4.-4sanitize(%mdc{correlationId:--})] %sanitize(%logger{30}):${patternExtension:- }%maybeJsonMsgAndEx%n
+                [%date{HH:mm:ss.SSS,UTC}Z %pidtid %-5level %-12.-12sanitize(%mdc{tenantId:--}) %-4.-4sanitize(%mdc{correlationId:--})] %sanitize(%logger{30}):${patternExtension:- }%maybeJsonMsgAndEx%n
             </pattern>
             <charset>UTF-8</charset>
         </encoder>


### PR DESCRIPTION
Also renamed the class to remove Pattern from it since that is not in any of the other converter class names.

@kusumaghoshdastidar I don't like "aProcessId" as a converter key.  Is there any particular reason that you chose that (i.e. does it meet some convention)?