### PR TITLE
D990090: Java 17 is now the minimum version

### DIFF
--- a/caf-logging-common/pom.xml
+++ b/caf-logging-common/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.github.cafapi.logging</groupId>
         <artifactId>caf-logging</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>caf-logging-common</artifactId>

--- a/caf-logging-log4j2/pom.xml
+++ b/caf-logging-log4j2/pom.xml
@@ -24,10 +24,14 @@
     <parent>
         <groupId>com.github.cafapi.logging</groupId>
         <artifactId>caf-logging</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>caf-logging-log4j2</artifactId>
+
+    <properties>
+        <enforceBannedDependencies>false</enforceBannedDependencies>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/caf-logging-logback-access-converters/pom.xml
+++ b/caf-logging-logback-access-converters/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.github.cafapi.logging</groupId>
         <artifactId>caf-logging</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>caf-logging-logback-access-converters</artifactId>

--- a/caf-logging-logback-converters/pom.xml
+++ b/caf-logging-logback-converters/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.github.cafapi.logging</groupId>
         <artifactId>caf-logging</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>caf-logging-logback-converters</artifactId>

--- a/caf-logging-logback/pom.xml
+++ b/caf-logging-logback/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.github.cafapi.logging</groupId>
         <artifactId>caf-logging</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>caf-logging-logback</artifactId>

--- a/official-build.props
+++ b/official-build.props
@@ -1,1 +1,1 @@
-SEPG_BUILD_ENV_IMAGE=cafapi/buildenv-jdk17:1.5.1
+SEPG_BUILD_ENV_IMAGE=cafapi/buildenv-jdk17:4.1.2

--- a/pom.xml
+++ b/pom.xml
@@ -24,12 +24,12 @@
     <parent>
         <groupId>com.github.cafapi</groupId>
         <artifactId>caf-common-parent</artifactId>
-        <version>2.1.0-129</version>
+        <version>5.0.0-431</version>
     </parent>
 
     <groupId>com.github.cafapi.logging</groupId>
     <artifactId>caf-logging</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <description>CAF Standard Logback Configuration</description>
@@ -73,8 +73,6 @@
 
     <properties>
         <copyrightYear>2024</copyrightYear>
-        <copyrightNotice>Copyright ${project.inceptionYear}-${copyrightYear} Open Text.</copyrightNotice>
-        <enforceCorrectDependencies>true</enforceCorrectDependencies>
         <logbackVersion>1.2.3</logbackVersion>
     </properties>
 
@@ -110,12 +108,12 @@
             <dependency>
                 <groupId>com.github.cafapi.logging</groupId>
                 <artifactId>caf-logging-common</artifactId>
-                <version>2.2.0-SNAPSHOT</version>
+                <version>3.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.github.cafapi.logging</groupId>
                 <artifactId>caf-logging-logback-converters</artifactId>
-                <version>2.2.0-SNAPSHOT</version>
+                <version>3.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.github.cafapi.common</groupId>

--- a/release-notes-2.2.0.md
+++ b/release-notes-2.2.0.md
@@ -1,9 +1,0 @@
-!not-ready-for-release!
-
-#### Version Number
-${version-number}
-
-#### New Features
-- US914108: Version Currency: JUnit 5 migration
-
-#### Known Issues

--- a/release-notes-3.0.0.md
+++ b/release-notes-3.0.0.md
@@ -1,0 +1,12 @@
+#### Version Number
+${version-number}
+
+#### New Features
+- None
+
+#### Breaking Changes
+- **D990090:** Java 8 and Java 11 support dropped  
+  Java 17 is now the minimum supported version.
+
+#### Known Issues
+- None


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=990090

In #33 we moved to a version of `util-process-identifier` that requires Java 17.